### PR TITLE
Added full generic type definitions, and improved `get` definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ Feel free to open Issues/PRs with suggestions/problems/improvements.
 
 ### Changelog
 
+
+#### `1.0.0`
+
+- Added extra type inference and enforcement to Oaty, this means that an array can be initialised `new OatyArray([{ myKey: "myValue" }])` without needing to provide a type.
+- `keys` input is now enforced to a subset of the keys of the given type
+- `keys` input will now be used to enforce that only valid objects are transposed by Oaty
+- `.keys` will now always return either an array containing all the auto transposed keys, or an array of the configured keys, and is now type correct.
+- Oaty will now enforce the correct keys are the objects of `.push` meaning that an error will be thrown at compile time if an invalid object is being passed to Oaty.
+- Updated overloads on `.get` to return the correct types depending on usage
+- Updated to `typescript@3.8`
+- Added `tsd` tests
+
 #### `0.4.0`
 
 - Oaty can now be initialised with `new OatyArray<T>()` so that `.get` , `.data`, and `.transposed` return data of type `T`. This is completely optional as `T` defaults to `any`.

--- a/benchmark/index.spec.ts
+++ b/benchmark/index.spec.ts
@@ -7,7 +7,7 @@ const testArray = [{ a: 1, b: 1, fruit: 'apple' },
 const results: any[] = []
 
 function time(runs: number) {
-  const oaty = new OatyArray({data: testArray})
+  const oaty = new OatyArray(testArray)
 
   const oatyTimes: number[] = []
   const oatyResults = []

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,7 +17,7 @@ export declare class OatyArray<T extends Object = {}, K extends keyof T = keyof 
     readonly data: T[];
     readonly transposed: Transposed<T, K>;
     get<A extends K>(keyName: A): TransposedValues<T, A>;
-    get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
+    get<A extends K>(keyName: A, keyValue: T[A]): T[];
     push(...data: T[]): number;
     private transpose;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,7 +17,7 @@ export declare class OatyArray<T extends Object = {}, K extends keyof T = keyof 
     readonly data: T[];
     readonly transposed: Transposed<T, K>;
     get<A extends K>(keyName: A): TransposedValues<T, A>;
-    get<A extends K>(keyName: A, keyValue: T[A]): T[];
+    get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
     push(...data: T[]): number;
     private transpose;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,24 +1,32 @@
 export interface Options<K> {
     keys?: K[];
 }
-declare type TransposedValues<T, K extends keyof T, V extends T[K] = T[K]> = {
-    [A in V extends string | number | symbol ? V : never]: T[] | undefined;
+declare type TransposedValues<T, K extends keyof T> = {
+    [V in T[K] extends string | number | symbol ? T[K] : never]: T[] | undefined;
 };
 export declare type Transposed<T, K extends keyof T> = {
-    [A in keyof T]: TransposedValues<T, K>;
+    [Key in keyof T]: TransposedValues<T, K>;
 };
-export declare class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
-    private _data;
+/**
+ * If T is not never, use T. Otherwise, infer the type from the keys K
+ */
+declare type InferType<T, K extends keyof any> = [T] extends [never] ? [K] extends [never] ? any : {
+    [Key in K]: any;
+} & {
+    [Key in string | number | symbol]: any;
+} : T;
+export declare class OatyArray<T = never, K extends keyof T = never> {
     private _options;
     private _transposed;
-    constructor(_data?: T[], _options?: Options<K>);
-    readonly keys: K[] | undefined;
-    readonly length: number;
-    readonly data: T[];
-    readonly transposed: Transposed<T, K>;
-    get<A extends K>(keyName: A): TransposedValues<T, A>;
-    get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
-    push(...data: T[]): number;
+    private _data;
+    constructor(data?: readonly InferType<T, K>[], _options?: Options<K>);
+    get keys(): [K] extends [never] ? undefined : K[];
+    get length(): number;
+    get data(): InferType<T, K>[];
+    get transposed(): Transposed<InferType<T, K>, K>;
+    get<SK extends K>(keyName: SK): TransposedValues<InferType<T, K>, SK>;
+    get<SK extends K>(keyName: SK, keyValue: InferType<T, K>[SK]): InferType<T, K>[] | undefined;
+    push(...data: readonly InferType<T, K>[]): number;
     private transpose;
 }
 export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,23 +1,24 @@
-export interface Options {
-    keys?: string[];
+export interface Options<K> {
+    keys?: K[];
 }
-export declare type Transposed<T> = {
-    [key: string]: {
-        [key: string]: [T];
-    };
+declare type TransposedValues<T, K extends keyof T, V extends T[K] = T[K]> = {
+    [A in V extends string | number | symbol ? V : never]: T[];
 };
-export declare class OatyArray<T = any> {
+export declare type Transposed<T, K extends keyof T> = {
+    [A in keyof T]: TransposedValues<T, K>;
+};
+export declare class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
     private _data;
     private _options;
     private _transposed;
-    constructor(_data?: T[], _options?: Options);
-    readonly keys: string[] | undefined;
+    constructor(_data?: T[], _options?: Options<K>);
+    readonly keys: K[] | undefined;
     readonly length: number;
     readonly data: T[];
-    readonly transposed: Transposed<T>;
-    get(keyName: string, keyValue?: string): {
-        [key: string]: [T];
-    } | T[] | undefined;
+    readonly transposed: Transposed<T, K>;
+    get<A extends K>(keyName: A): TransposedValues<T, A>;
+    get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
     push(...data: T[]): number;
     private transpose;
 }
+export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -24,8 +24,8 @@ export declare class OatyArray<T = never, K extends keyof T = never> {
     get length(): number;
     get data(): InferType<T, K>[];
     get transposed(): Transposed<InferType<T, K>, K>;
-    get<SK extends K>(keyName: SK): TransposedValues<InferType<T, K>, SK>;
-    get<SK extends K>(keyName: SK, keyValue: InferType<T, K>[SK]): InferType<T, K>[] | undefined;
+    get<KN extends K>(keyName: KN): TransposedValues<InferType<T, K>, KN>;
+    get<KN extends K>(keyName: KN, keyValue: InferType<T, K>[KN]): InferType<T, K>[] | undefined;
     push(...data: readonly InferType<T, K>[]): number;
     private transpose;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -16,10 +16,10 @@ declare type InferType<T, K extends keyof any> = [T] extends [never] ? [K] exten
     [Key in string | number | symbol]: any;
 } : T;
 export declare class OatyArray<T = never, K extends keyof T = keyof T> {
-    private _options;
     private _transposed;
     private _data;
-    constructor(data?: readonly InferType<T, K>[], _options?: Options<K>);
+    private _options;
+    constructor(data?: readonly InferType<T, K>[], options?: Options<K>);
     get keys(): [T] extends [never] ? K[] | undefined : K[];
     get length(): number;
     get data(): InferType<T, K>[];

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -20,7 +20,7 @@ export declare class OatyArray<T = never, K extends keyof T = keyof T> {
     private _data;
     private _options;
     constructor(data?: readonly InferType<T, K>[], options?: Options<K>);
-    get keys(): [T] extends [never] ? K[] | undefined : K[];
+    get keys(): K[];
     get length(): number;
     get data(): InferType<T, K>[];
     get transposed(): Transposed<InferType<T, K>, K>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -15,12 +15,12 @@ declare type InferType<T, K extends keyof any> = [T] extends [never] ? [K] exten
 } & {
     [Key in string | number | symbol]: any;
 } : T;
-export declare class OatyArray<T = never, K extends keyof T = never> {
+export declare class OatyArray<T = never, K extends keyof T = keyof T> {
     private _options;
     private _transposed;
     private _data;
     constructor(data?: readonly InferType<T, K>[], _options?: Options<K>);
-    get keys(): [K] extends [never] ? undefined : K[];
+    get keys(): [T] extends [never] ? K[] | undefined : K[];
     get length(): number;
     get data(): InferType<T, K>[];
     get transposed(): Transposed<InferType<T, K>, K>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,7 +2,7 @@ export interface Options<K> {
     keys?: K[];
 }
 declare type TransposedValues<T, K extends keyof T, V extends T[K] = T[K]> = {
-    [A in V extends string | number | symbol ? V : never]: T[];
+    [A in V extends string | number | symbol ? V : never]: T[] | undefined;
 };
 export declare type Transposed<T, K extends keyof T> = {
     [A in keyof T]: TransposedValues<T, K>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,13 +1,25 @@
 "use strict";
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 var OatyArray = /** @class */ (function () {
-    function OatyArray(_data, _options) {
-        if (_data === void 0) { _data = []; }
-        if (_options === void 0) { _options = {}; }
-        this._data = _data;
+    function OatyArray(data, _options) {
+        if (data === void 0) { data = []; }
+        if (_options === void 0) { _options = {
+            keys: data.length > 0 ?
+                Object.keys(data[0])
+                :
+                    undefined
+        }; }
         this._options = _options;
         this._transposed = {};
-        this.transpose(_data);
+        this._data = __spreadArrays(data);
+        this.transpose(this._data);
     }
     Object.defineProperty(OatyArray.prototype, "keys", {
         get: function () {
@@ -38,6 +50,9 @@ var OatyArray = /** @class */ (function () {
         configurable: true
     });
     OatyArray.prototype.get = function (keyName, keyValue) {
+        if (this._transposed[keyName] === undefined) {
+            throw new ReferenceError("The key '" + keyName + "' has not been transposed");
+        }
         if (keyValue === undefined) {
             return this._transposed[keyName];
         }
@@ -54,10 +69,14 @@ var OatyArray = /** @class */ (function () {
     };
     OatyArray.prototype.transpose = function (data) {
         var _a;
+        var _b;
         for (var _i = 0, data_1 = data; _i < data_1.length; _i++) {
             var datum = data_1[_i];
-            for (var _b = 0, _c = (this.keys || Object.keys(datum)); _b < _c.length; _b++) {
-                var key = _c[_b];
+            for (var _c = 0, _d = ((_b = this.keys) !== null && _b !== void 0 ? _b : Object.keys(datum)); _c < _d.length; _c++) {
+                var key = _d[_c];
+                if (datum[key] === undefined) {
+                    continue;
+                }
                 var searchKey = datum[key];
                 if (this._transposed[key] === undefined) {
                     this._transposed[key] = (_a = {}, _a[searchKey] = [datum], _a);

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,30 +7,19 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
     return r;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Extract all the keys from the given array of objects
- */
-var keys = function (data) {
-    return Array.from(data
-        .map(function (item) { return Object.keys(item); })
-        .reduce(function (keys, itemKeys) {
-        itemKeys.forEach(function (key) { return keys.add(key); });
-        return keys;
-    }, new Set()));
-};
 var OatyArray = /** @class */ (function () {
     function OatyArray(data, options) {
         if (data === void 0) { data = []; }
+        if (options === void 0) { options = {}; }
         this._transposed = {};
         this._data = __spreadArrays(data);
-        this._options = options !== null && options !== void 0 ? options : {
-            keys: data.length > 0 ? keys(data) : undefined
-        };
+        this._options = options;
         this.transpose(this._data);
     }
     Object.defineProperty(OatyArray.prototype, "keys", {
         get: function () {
-            return this._options.keys;
+            var _a;
+            return ((_a = this._options.keys) !== null && _a !== void 0 ? _a : Object.keys(this._transposed));
         },
         enumerable: true,
         configurable: true
@@ -79,7 +68,7 @@ var OatyArray = /** @class */ (function () {
         var _b;
         for (var _i = 0, data_1 = data; _i < data_1.length; _i++) {
             var datum = data_1[_i];
-            for (var _c = 0, _d = ((_b = this.keys) !== null && _b !== void 0 ? _b : Object.keys(datum)); _c < _d.length; _c++) {
+            for (var _c = 0, _d = ((_b = this._options.keys) !== null && _b !== void 0 ? _b : Object.keys(datum)); _c < _d.length; _c++) {
                 var key = _d[_c];
                 if (datum[key] === undefined) {
                     continue;

--- a/dist/index.js
+++ b/dist/index.js
@@ -58,9 +58,6 @@ var OatyArray = /** @class */ (function () {
             var datum = data_1[_i];
             for (var _b = 0, _c = (this.keys || Object.keys(datum)); _b < _c.length; _b++) {
                 var key = _c[_b];
-                if (datum[key] === undefined) {
-                    continue;
-                }
                 var searchKey = datum[key];
                 if (this._transposed[key] === undefined) {
                     this._transposed[key] = (_a = {}, _a[searchKey] = [datum], _a);

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,18 +7,25 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
     return r;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Extract all the keys from the given array of objects
+ */
+var keys = function (data) {
+    return Array.from(data
+        .map(function (item) { return Object.keys(item); })
+        .reduce(function (keys, itemKeys) {
+        itemKeys.forEach(function (key) { return keys.add(key); });
+        return keys;
+    }, new Set()));
+};
 var OatyArray = /** @class */ (function () {
-    function OatyArray(data, _options) {
+    function OatyArray(data, options) {
         if (data === void 0) { data = []; }
-        if (_options === void 0) { _options = {
-            keys: data.length > 0 ?
-                Object.keys(data[0])
-                :
-                    undefined
-        }; }
-        this._options = _options;
         this._transposed = {};
         this._data = __spreadArrays(data);
+        this._options = options !== null && options !== void 0 ? options : {
+            keys: data.length > 0 ? keys(data) : undefined
+        };
         this.transpose(this._data);
     }
     Object.defineProperty(OatyArray.prototype, "keys", {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,9 +38,6 @@ var OatyArray = /** @class */ (function () {
         configurable: true
     });
     OatyArray.prototype.get = function (keyName, keyValue) {
-        if (this._transposed[keyName] === undefined) {
-            throw new ReferenceError("The key '" + keyName + "' has not been transposed");
-        }
         if (keyValue === undefined) {
             return this._transposed[keyName];
         }
@@ -64,15 +61,16 @@ var OatyArray = /** @class */ (function () {
                 if (datum[key] === undefined) {
                     continue;
                 }
+                var searchKey = datum[key];
                 if (this._transposed[key] === undefined) {
-                    this._transposed[key] = (_a = {}, _a[datum[key]] = [datum], _a);
+                    this._transposed[key] = (_a = {}, _a[searchKey] = [datum], _a);
                     continue;
                 }
-                if (this._transposed[key][datum[key]] === undefined) {
-                    this._transposed[key][datum[key]] = [datum];
+                if (this._transposed[key][searchKey] === undefined) {
+                    this._transposed[key][searchKey] = [datum];
                     continue;
                 }
-                this._transposed[key][datum[key]].push(datum);
+                this._transposed[key][searchKey].push(datum);
             }
         }
     };

--- a/index.ts
+++ b/index.ts
@@ -34,8 +34,8 @@ export class OatyArray<T = never, K extends keyof T = keyof T> {
     this.transpose(this._data);
   }
 
-  get keys(): [T] extends [never] ? K[] | undefined : K[] {
-    return (this._options.keys ?? Object.keys(this._transposed)) as [T] extends [never] ? K[] | undefined : K[]
+  get keys(): K[] {
+    return (this._options.keys ?? Object.keys(this._transposed)) as K[]
   }
 
   get length(): number {

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
   }
 
   public get<A extends K>(keyName: A): TransposedValues<T, A>;
-  public get<A extends K>(keyName: A, keyValue: T[A]): T[];
+  public get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
   public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] | undefined {
     if (keyValue === undefined) {
       return this._transposed[keyName]

--- a/index.ts
+++ b/index.ts
@@ -54,9 +54,9 @@ export class OatyArray<T = never, K extends keyof T = never> {
     return this._transposed
   }
 
-  public get<SK extends K>(keyName: SK): TransposedValues<InferType<T, K>, SK>;
-  public get<SK extends K>(keyName: SK, keyValue: InferType<T, K>[SK]): InferType<T, K>[] | undefined;
-  public get<SK extends K>(keyName: SK, keyValue?: InferType<T, K>[SK]): TransposedValues<InferType<T, K>, SK> | InferType<T, K>[] | undefined {
+  public get<KN extends K>(keyName: KN): TransposedValues<InferType<T, K>, KN>;
+  public get<KN extends K>(keyName: KN, keyValue: InferType<T, K>[KN]): InferType<T, K>[] | undefined;
+  public get<KN extends K>(keyName: KN, keyValue?: InferType<T, K>[KN]): TransposedValues<InferType<T, K>, KN> | InferType<T, K>[] | undefined {
     if (this._transposed[keyName] === undefined) {
       throw new ReferenceError(`The key '${keyName}' has not been transposed`)
     }
@@ -65,7 +65,7 @@ export class OatyArray<T = never, K extends keyof T = never> {
       return this._transposed[keyName]
     }
 
-    return this._transposed[keyName][keyValue as keyof TransposedValues<InferType<T, K>, SK>]
+    return this._transposed[keyName][keyValue as keyof TransposedValues<InferType<T, K>, KN>]
   }
 
   public push(...data: readonly InferType<T, K>[]) {

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ type InferType<T, K extends keyof any> =
     :
     T;
 
-export class OatyArray<T = never, K extends keyof T = never> {
+export class OatyArray<T = never, K extends keyof T = keyof T> {
   private _transposed = {} as Transposed<InferType<T, K>, K>;
   private _data: InferType<T, K>[];
 
@@ -38,8 +38,8 @@ export class OatyArray<T = never, K extends keyof T = never> {
     this.transpose(this._data)
   }
 
-  get keys(): [K] extends [never] ? undefined : K[] {
-    return this._options.keys as [K] extends [never] ? undefined : K[]
+  get keys(): [T] extends [never] ? K[] | undefined : K[] {
+    return this._options.keys as [T] extends [never] ? K[] | undefined : K[]
   }
 
   get length(): number {

--- a/index.ts
+++ b/index.ts
@@ -1,41 +1,51 @@
 export interface Options<K> {
-  keys?: K[] // only these keys will be transposed
+  keys?: K[]; // only these keys will be transposed
 }
 
 type TransposedValues<T, K extends keyof T> = {
-  [V in T[K] extends string | number | symbol ? T[K] : never]: T[] | undefined
+  [V in T[K] extends string | number | symbol ? T[K] : never]: T[] | undefined;
 };
 
 export type Transposed<T, K extends keyof T> = {
-  [Key in keyof T]: TransposedValues<T, K>
+  [Key in keyof T]: TransposedValues<T, K>;
 };
 
 /**
  * If T is not never, use T. Otherwise, infer the type from the keys K
  */
-type InferType<T, K extends keyof any> =
-  [T] extends [never] ?
-    [K] extends [never] ?
-      any
-      :
-      {[Key in K]: any} & { [Key in string | number | symbol]: any }
-    :
-    T;
+type InferType<T, K extends keyof any> = [T] extends [never]
+  ? [K] extends [never]
+    ? any
+    : { [Key in K]: any } & { [Key in string | number | symbol]: any }
+  : T;
+
+/**
+ * Extract all the keys from the given array of objects
+ */
+const keys = <T>(data: readonly T[]): (keyof T)[] =>
+  Array.from(
+    data
+      .map((item) => Object.keys(item))
+      .reduce((keys, itemKeys) => {
+        itemKeys.forEach((key) => keys.add(key as keyof T));
+        return keys;
+      }, new Set<keyof T>())
+  );
 
 export class OatyArray<T = never, K extends keyof T = keyof T> {
   private _transposed = {} as Transposed<InferType<T, K>, K>;
   private _data: InferType<T, K>[];
+  private _options: Options<K>;
 
   constructor(
-      data: readonly InferType<T, K>[] = [], 
-      private _options: Options<K> = { 
-        keys: data.length > 0 ? 
-          Object.keys(data[0] as object) as K[] 
-          : 
-          undefined
-      }) {
+    data: readonly InferType<T, K>[] = [],
+    options?: Options<K>
+  ) {
     this._data = [...data];
-    this.transpose(this._data)
+    this._options = options ?? { 
+      keys: data.length > 0 ? (keys(data) as K[]) : undefined 
+    }
+    this.transpose(this._data);
   }
 
   get keys(): [T] extends [never] ? K[] | undefined : K[] {

--- a/index.ts
+++ b/index.ts
@@ -51,10 +51,6 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
   private transpose(data: T[]) {
     for (const datum of data) {
       for (const key of (this.keys || Object.keys(datum) as (keyof typeof datum)[])) {
-        if (datum[key] === undefined) {
-          continue
-        }
-
         const searchKey = datum[key] as keyof TransposedValues<T, K>;
         
         if (this._transposed[key] === undefined) {

--- a/index.ts
+++ b/index.ts
@@ -52,7 +52,10 @@ export class OatyArray<T = never, K extends keyof T = keyof T> {
 
   public get<KN extends K>(keyName: KN): TransposedValues<InferType<T, K>, KN>;
   public get<KN extends K>(keyName: KN, keyValue: InferType<T, K>[KN]): InferType<T, K>[] | undefined;
-  public get<KN extends K>(keyName: KN, keyValue?: InferType<T, K>[KN]): TransposedValues<InferType<T, K>, KN> | InferType<T, K>[] | undefined {
+  public get<KN extends K>(
+    keyName: KN, 
+    keyValue?: InferType<T, K>[KN]
+  ): TransposedValues<InferType<T, K>, KN> | InferType<T, K>[] | undefined {
     if (this._transposed[keyName] === undefined) {
       throw new ReferenceError(`The key '${keyName}' has not been transposed`)
     }

--- a/index.ts
+++ b/index.ts
@@ -19,18 +19,6 @@ type InferType<T, K extends keyof any> = [T] extends [never]
     : { [Key in K]: any } & { [Key in string | number | symbol]: any }
   : T;
 
-/**
- * Extract all the keys from the given array of objects
- */
-const keys = <T>(data: readonly T[]): (keyof T)[] =>
-  Array.from(
-    data
-      .map((item) => Object.keys(item))
-      .reduce((keys, itemKeys) => {
-        itemKeys.forEach((key) => keys.add(key as keyof T));
-        return keys;
-      }, new Set<keyof T>())
-  );
 
 export class OatyArray<T = never, K extends keyof T = keyof T> {
   private _transposed = {} as Transposed<InferType<T, K>, K>;
@@ -39,17 +27,15 @@ export class OatyArray<T = never, K extends keyof T = keyof T> {
 
   constructor(
     data: readonly InferType<T, K>[] = [],
-    options?: Options<K>
+    options: Options<K> = {}
   ) {
     this._data = [...data];
-    this._options = options ?? { 
-      keys: data.length > 0 ? (keys(data) as K[]) : undefined 
-    }
+    this._options = options;
     this.transpose(this._data);
   }
 
   get keys(): [T] extends [never] ? K[] | undefined : K[] {
-    return this._options.keys as [T] extends [never] ? K[] | undefined : K[]
+    return (this._options.keys ?? Object.keys(this._transposed)) as [T] extends [never] ? K[] | undefined : K[]
   }
 
   get length(): number {
@@ -85,7 +71,7 @@ export class OatyArray<T = never, K extends keyof T = keyof T> {
 
   private transpose(data: readonly InferType<T, K>[]) {
     for (const datum of data) {
-      for (const key of (this.keys ?? Object.keys(datum) as (keyof typeof datum)[])) {
+      for (const key of (this._options.keys ?? Object.keys(datum) as (keyof typeof datum)[])) {
         if (datum[key] === undefined) {
           continue	
         }

--- a/index.ts
+++ b/index.ts
@@ -34,8 +34,8 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
   }
 
   public get<A extends K>(keyName: A): TransposedValues<T, A>;
-  public get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
-  public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] | undefined {
+  public get<A extends K>(keyName: A, keyValue: T[A]): T[];
+  public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] {
     if (keyValue === undefined) {
       return this._transposed[keyName]
     }

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ export interface Options<K> {
 }
 
 type TransposedValues<T, K extends keyof T, V extends T[K] = T[K]> = { 
-  [A in V extends string | number | symbol ? V : never]: T[] 
+  [A in V extends string | number | symbol ? V : never]: T[] | undefined
 };
 
 export type Transposed<T, K extends keyof T> = {
@@ -35,7 +35,7 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
 
   public get<A extends K>(keyName: A): TransposedValues<T, A>;
   public get<A extends K>(keyName: A, keyValue: T[A]): T[];
-  public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] {
+  public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] | undefined {
     if (keyValue === undefined) {
       return this._transposed[keyName]
     }
@@ -66,7 +66,7 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
           this._transposed[key][searchKey] = [datum]
           continue
         }
-        this._transposed[key][searchKey].push(datum)
+        this._transposed[key][searchKey]!.push(datum)
       }
     }
   }

--- a/index.ts
+++ b/index.ts
@@ -2,12 +2,12 @@ export interface Options<K> {
   keys?: K[] // only these keys will be transposed
 }
 
-type TransposedValues<T, K extends keyof T, V extends T[K] = T[K]> = { 
-  [A in V extends string | number | symbol ? V : never]: T[] | undefined
+type TransposedValues<T, K extends keyof T> = { 
+  [V in T[K] extends string | number | symbol ? T[K] : never]: T[] | undefined
 };
 
 export type Transposed<T, K extends keyof T> = {
-  [A in keyof T] : TransposedValues<T, K>
+  [Key in keyof T] : TransposedValues<T, K>
 };
 
 export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
@@ -33,14 +33,14 @@ export class OatyArray<T extends Object = {}, K extends keyof T = keyof T> {
     return this._transposed
   }
 
-  public get<A extends K>(keyName: A): TransposedValues<T, A>;
-  public get<A extends K>(keyName: A, keyValue: T[A]): T[] | undefined;
-  public get<A extends K>(keyName: A, keyValue?: T[A]): TransposedValues<T, A> | T[] | undefined {
+  public get(keyName: K): TransposedValues<T, typeof keyName>;
+  public get(keyName: K, keyValue: T[typeof keyName]): T[] | undefined;
+  public get(keyName: K, keyValue?: T[typeof keyName]): TransposedValues<T, typeof keyName> | T[] | undefined {
     if (keyValue === undefined) {
       return this._transposed[keyName]
     }
 
-    return this._transposed[keyName][keyValue as keyof TransposedValues<T, A>]
+    return this._transposed[keyName][keyValue as keyof TransposedValues<T, typeof keyName>]
   }
 
   public push(...data: T[]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,10 +158,49 @@
         }
       }
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
       "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mocha": {
@@ -176,10 +215,25 @@
       "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
       "dev": true
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
       "dev": true
     },
     "ansi-regex": {
@@ -227,10 +281,73 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "balanced-match": {
@@ -238,6 +355,84 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -247,6 +442,35 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "browser-stdout": {
@@ -267,6 +491,23 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
     "caching-transform": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -279,10 +520,41 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
     "chai": {
@@ -327,6 +599,41 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -343,6 +650,16 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -371,11 +688,48 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -385,6 +739,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "cp-file": {
       "version": "6.2.0",
@@ -399,6 +759,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -410,6 +779,21 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
       }
     },
     "debug": {
@@ -427,6 +811,30 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -435,6 +843,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -454,10 +868,75 @@
         "object-keys": "^1.0.12"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
+      "requires": {
+        "path-type": "^3.0.0"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "emoji-regex": {
@@ -521,6 +1000,19 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint-formatter-pretty": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
+      "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^2.0.0",
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.0.0",
+        "plur": "^2.1.2",
+        "string-width": "^2.0.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -546,6 +1038,179 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "find-cache-dir": {
@@ -577,6 +1242,12 @@
         "is-buffer": "~2.0.3"
       }
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -597,6 +1268,15 @@
             "which": "^1.2.9"
           }
         }
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
       }
     },
     "fs.realpath": {
@@ -632,6 +1312,12 @@
         "pump": "^3.0.0"
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -646,11 +1332,90 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^1.0.2",
+        "dir-glob": "^2.2.2",
+        "fast-glob": "^2.2.6",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.3",
+        "pify": "^4.0.1",
+        "slash": "^2.0.0"
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
     },
     "graceful-fs": {
       "version": "4.2.2",
@@ -697,6 +1462,44 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -718,10 +1521,28 @@
       "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "inflight": {
@@ -740,11 +1561,49 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -764,16 +1623,169 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -784,6 +1796,12 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -800,10 +1818,28 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -927,6 +1963,21 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
+      }
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -987,6 +2038,22 @@
         "chalk": "^2.0.1"
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -1022,6 +2089,27 @@
         "p-defer": "^1.0.0"
       }
     },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -1033,6 +2121,93 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -1040,6 +2215,33 @@
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
+      }
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mimic-fn": {
@@ -1062,6 +2264,37 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1108,6 +2341,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "neo-async": {
       "version": "2.6.1",
@@ -1197,11 +2449,57 @@
         "yargs-parser": "^13.0.0"
       }
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
     },
     "object.assign": {
       "version": "4.1.0",
@@ -1223,6 +2521,15 @@
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -1315,6 +2622,18 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -1324,6 +2643,18 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -1335,6 +2666,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -1387,6 +2724,27 @@
         "find-up": "^3.0.0"
       }
     },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^1.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1401,6 +2759,32 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -1424,6 +2808,45 @@
         "read-pkg": "^3.0.0"
       }
     },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -1432,6 +2855,18 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1460,6 +2895,18 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -1475,17 +2922,58 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -1508,11 +2996,164 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.12",
@@ -1523,6 +3164,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spawn-wrap": {
       "version": "1.4.3",
@@ -1570,11 +3217,41 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1607,6 +3284,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1622,6 +3305,49 @@
         "has-flag": "^3.0.0"
       }
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -1634,10 +3360,70 @@
         "require-main-filename": "^2.0.0"
       }
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
       "dev": true
     },
     "ts-node": {
@@ -1651,6 +3437,20 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
+      }
+    },
+    "tsd": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.11.0.tgz",
+      "integrity": "sha512-klKMNC0KRzUIaLJG8XqkvH/9rKwYX74xpqJBN8spWjYUDojAesd6AfDCT5dray+yhLfTGkem7O3nU6i4KwzNDw==",
+      "dev": true,
+      "requires": {
+        "eslint-formatter-pretty": "^1.3.0",
+        "globby": "^9.1.0",
+        "meow": "^5.0.0",
+        "path-exists": "^3.0.0",
+        "read-pkg-up": "^4.0.0",
+        "update-notifier": "^2.5.0"
       }
     },
     "tslib": {
@@ -1704,9 +3504,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {
@@ -1719,6 +3519,112 @@
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
       }
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "uuid": {
       "version": "3.3.3",
@@ -1758,6 +3664,15 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
       }
     },
     "wordwrap": {
@@ -1829,6 +3744,12 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "benchmark": "ts-node benchmark/index.spec.ts --outDir ./benchmark",
     "build": "npm run clean && tsc",
     "test": "mocha --require ts-node/register test/**/*.spec.ts --reporter list",
+    "test-d": "npm run build && tsd",
     "format": "tslint --project . --fix",
-    "ci": "npm run coverage",
+    "ci": "npm run coverage && npm run test-d",
     "postversion": "git push && git push --tags",
     "prepublishOnly": "npm run ci",
     "preversion": "npm run ci"
@@ -51,9 +52,13 @@
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3",
     "ts-node": "^8.1.0",
+    "tsd": "^0.11.0",
     "tslint": "^5.20.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.8.3"
   },
+  "tsd": {
+		"directory": "test"
+	},
   "nyc": {
     "extension": [
       ".ts"

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -62,19 +62,6 @@ describe('OatyArray', () => {
         fixture.thenKeysEquals(['a'])
       })
     })
-
-    context('([...], {keys: undefined})', () => {
-      it('initialises', () => {
-        const initial = [
-         { a: 1, b: 1, fruit: 'apple' },
-         { a: 1, b: 2, fruit: 'apple' },
-         { a: 1, b: 3, fruit: 'banana' }]
-        fixture.givenOatyArray(initial, {keys: undefined})
-        fixture.thenOatyArrayExists()
-        fixture.thenOriginalsEquals(initial)
-        fixture.thenKeysEquals(['a'])
-      })
-    })
   })
 
   describe('.keys', () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -32,7 +32,7 @@ describe('OatyArray', () => {
       it('initialises', () => {
         const initial = [
          { a: 1, b: 1, fruit: 'apple' },
-         { a: 1, b: 3, fruit: 'banana' }, 
+         { a: 1, b: 3, fruit: 'banana' },
          { a: 2, b: 4, food: 'yum' }
         ]
         fixture.givenOatyArray(initial)
@@ -42,12 +42,12 @@ describe('OatyArray', () => {
       })
     })
 
-    context('([], {keys})', () => {	
-      it('initialises', () => {	
-        fixture.givenOatyArray([], {keys: ['a', 'b', 'fruit']})	
-        fixture.thenOatyArrayExists()	
-        fixture.thenKeysEquals(['a', 'b', 'fruit'])	
-      })	
+    context('([], {keys})', () => {
+      it('initialises', () => {
+        fixture.givenOatyArray([], {keys: ['a', 'b', 'fruit']})
+        fixture.thenOatyArrayExists()
+        fixture.thenKeysEquals(['a', 'b', 'fruit'])
+      })
     });
 
     context('([...], {keys})', () => {
@@ -62,15 +62,28 @@ describe('OatyArray', () => {
         fixture.thenKeysEquals(['a'])
       })
     })
+
+    context('([...], {keys: undefined})', () => {
+      it('initialises', () => {
+        const initial = [
+         { a: 1, b: 1, fruit: 'apple' },
+         { a: 1, b: 2, fruit: 'apple' },
+         { a: 1, b: 3, fruit: 'banana' }]
+        fixture.givenOatyArray(initial, {keys: undefined})
+        fixture.thenOatyArrayExists()
+        fixture.thenOriginalsEquals(initial)
+        fixture.thenKeysEquals(['a'])
+      })
+    })
   })
 
-  describe('.keys', () => {	
-    context('with initialised data', () => {	
-      it('returns initialised data', () => {	
-        fixture.givenOatyArray([], {keys: ['a']})	
-        fixture.thenKeysEquals(['a'])	
-      })	
-    })	
+  describe('.keys', () => {
+    context('with initialised data', () => {
+      it('returns initialised data', () => {
+        fixture.givenOatyArray([], {keys: ['a']})
+        fixture.thenKeysEquals(['a'])
+      })
+    })
   })
 
   describe('.length', () => {
@@ -141,29 +154,29 @@ describe('OatyArray', () => {
       fixture.thenCountIs(6)
     })
 
-    it('transposes only .keys', () => {	
-      const keys = ['fruit']	
-      const push = [	
-       { a: 5, b: 5, fruit: 'potato' },	
-       { a: 6, b: 6, fruit: 'courgette' }]	
-      fixture.givenOatyArray([], {keys})	
-      fixture.whenDataIsPushed(push)	
-      fixture.thenTransposedEquals({	
-        fruit: {	
-          courgette: [{ a: 6, b: 6, fruit: 'courgette' }],	
-          potato: [{ a: 5, b: 5, fruit: 'potato' }],	
-        },	
-      })	
-    })	
+    it('transposes only .keys', () => {
+      const keys = ['fruit']
+      const push = [
+       { a: 5, b: 5, fruit: 'potato' },
+       { a: 6, b: 6, fruit: 'courgette' }]
+      fixture.givenOatyArray([], {keys})
+      fixture.whenDataIsPushed(push)
+      fixture.thenTransposedEquals({
+        fruit: {
+          courgette: [{ a: 6, b: 6, fruit: 'courgette' }],
+          potato: [{ a: 5, b: 5, fruit: 'potato' }],
+        },
+      })
+    })
 
-    it('does not tranpose objects with missing .keys', () => {	
-      const keys = ['fruit']	
-      const push = [	
-       { a: 5, b: 5 },	
-       { a: 6, b: 6 }]	
-      fixture.givenOatyArray([], {keys})	
-      fixture.whenDataIsPushed(push)	
-      fixture.thenTransposedEquals({})	
+    it('does not tranpose objects with missing .keys', () => {
+      const keys = ['fruit']
+      const push = [
+       { a: 5, b: 5 },
+       { a: 6, b: 6 }]
+      fixture.givenOatyArray([], {keys})
+      fixture.whenDataIsPushed(push)
+      fixture.thenTransposedEquals({})
     })
   })
 
@@ -223,14 +236,14 @@ describe('OatyArray', () => {
         })
       })
 
-      context('querying for non-existent key', () => {	
-        it('throws a ReferenceError', () => {	
-          const testArray = [{ a: 1, b: 1}]	
-          fixture.givenOatyArray(testArray)	
-          expect(() => {	
-            fixture.whenGetIsCalled('fruit')	
-          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)	
-        })	
+      context('querying for non-existent key', () => {
+        it('throws a ReferenceError', () => {
+          const testArray = [{ a: 1, b: 1}]
+          fixture.givenOatyArray(testArray)
+          expect(() => {
+            fixture.whenGetIsCalled('fruit')
+          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)
+        })
       })
     })
     describe('(key, value)', () => {
@@ -269,14 +282,14 @@ describe('OatyArray', () => {
         })
       })
 
-      context('querying for non-existent key', () => {	
-        it('throws a ReferenceError', () => {	
-          const testArray = [{ a: 1, b: 1}]	
-          fixture.givenOatyArray(testArray)	
-          expect(() => {	
-            fixture.whenGetIsCalled('fruit', 'carrot')	
-          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)	
-        })	
+      context('querying for non-existent key', () => {
+        it('throws a ReferenceError', () => {
+          const testArray = [{ a: 1, b: 1}]
+          fixture.givenOatyArray(testArray)
+          expect(() => {
+            fixture.whenGetIsCalled('fruit', 'carrot')
+          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)
+        })
       })
 
       context('querying for non-existent value', () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -309,7 +309,7 @@ class Fixture {
   public thenMatchesEquals<T>(matches: T, type?: string) {
     expect(this._matches).to.deep.equal(matches)
     if (type === 'Dummy') {
-      expect(this._matches![0]).to.be.an.instanceOf(Dummy)
+      expect((this._matches as any)[0]).to.be.an.instanceOf(Dummy)
     }
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -39,14 +39,6 @@ describe('OatyArray', () => {
       })
     })
 
-    context('([], {keys})', () => {
-      it('initialises', () => {
-        fixture.givenOatyArray([], {keys: ['a', 'b', 'fruit']})
-        fixture.thenOatyArrayExists()
-        fixture.thenKeysEquals(['a', 'b', 'fruit'])
-      })
-    })
-
     context('([...], {keys})', () => {
       it('initialises', () => {
         const initial = [
@@ -56,15 +48,6 @@ describe('OatyArray', () => {
         fixture.givenOatyArray(initial, {keys: ['a']})
         fixture.thenOatyArrayExists()
         fixture.thenOriginalsEquals(initial)
-        fixture.thenKeysEquals(['a'])
-      })
-    })
-  })
-
-  describe('.keys', () => {
-    context('with initialised data', () => {
-      it('returns initialised data', () => {
-        fixture.givenOatyArray([], {keys: ['a']})
         fixture.thenKeysEquals(['a'])
       })
     })
@@ -137,31 +120,6 @@ describe('OatyArray', () => {
       fixture.whenDataIsPushed(push)
       fixture.thenCountIs(6)
     })
-
-    it('transposes only .keys', () => {
-      const keys = ['fruit']
-      const push = [
-       { a: 5, b: 5, fruit: 'potato' },
-       { a: 6, b: 6, fruit: 'courgette' }]
-      fixture.givenOatyArray([], {keys})
-      fixture.whenDataIsPushed(push)
-      fixture.thenTransposedEquals({
-        fruit: {
-          courgette: [{ a: 6, b: 6, fruit: 'courgette' }],
-          potato: [{ a: 5, b: 5, fruit: 'potato' }],
-        },
-      })
-    })
-
-    it('does not tranpose objects with missing .keys', () => {
-      const keys = ['fruit']
-      const push = [
-       { a: 5, b: 5 },
-       { a: 6, b: 6 }]
-      fixture.givenOatyArray([], {keys})
-      fixture.whenDataIsPushed(push)
-      fixture.thenTransposedEquals({})
-    })
   })
 
   describe('.get', () => {
@@ -219,16 +177,6 @@ describe('OatyArray', () => {
             potato: [{ a: 5, b: 5, fruit: 'potato' }]})
         })
       })
-
-      context('querying for non-existent key', () => {
-        it('throws a ReferenceError', () => {
-          const testArray = [{ a: 1, b: 1}]
-          fixture.givenOatyArray(testArray)
-          expect(() => {
-            fixture.whenGetIsCalled('fruit')
-          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)
-        })
-      })
     })
     describe('(key, value)', () => {
       context('initialised data', () => {
@@ -266,16 +214,6 @@ describe('OatyArray', () => {
         })
       })
 
-      context('querying for non-existent key', () => {
-        it('throws a ReferenceError', () => {
-          const testArray = [{ a: 1, b: 1}]
-          fixture.givenOatyArray(testArray)
-          expect(() => {
-            fixture.whenGetIsCalled('fruit', 'carrot')
-          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)
-        })
-      })
-
       context('querying for non-existent value', () => {
         it('returns undefined', () => {
           const testArray = [{ a: 1, b: 1, fruit: 'apple' }]
@@ -291,8 +229,8 @@ describe('OatyArray', () => {
     describe('.data', () => {
       context('initalised data', () => {
         it('returns data of type T[]', () => {
-          fixture.givenOatyArray<Dummy>([new Dummy()])
-          fixture.thenDataEquals<Dummy[]>([new Dummy()], 'Dummy')
+          fixture.givenOatyArray([new Dummy()])
+          fixture.thenDataEquals([new Dummy()], 'Dummy')
         })
       })
 
@@ -311,7 +249,7 @@ describe('OatyArray', () => {
       describe('initialised data', () => {
         it('returns data of type [T]', () => {
           fixture.givenOatyArray<Dummy>([new Dummy()])
-          fixture.thenTransposedEquals<Dummy>({
+          fixture.thenTransposedEquals({
             data: {
               hello: [
                 new Dummy(),
@@ -326,13 +264,13 @@ describe('OatyArray', () => {
 
 // tslint:disable-next-line: max-classes-per-file
 class Fixture {
-  private _oatyArray: OatyArray | undefined
+  private _oatyArray: OatyArray<any, any> | undefined
 
   private _count: number | undefined
   private _matches: { [key: string]: [any] } | any[] | undefined
 
-  public givenOatyArray<T>(data?: T[], options?: Options) {
-    this._oatyArray = new OatyArray<T>(data, options)
+  public givenOatyArray<T>(data?: T[], options?: Options<keyof T>) {
+    this._oatyArray = new OatyArray(data, options)
   }
 
   public whenDataIsPushed(data: object[]) {
@@ -361,10 +299,10 @@ class Fixture {
     }
   }
 
-  public thenTransposedEquals<T>(transposed: Transposed<T>, type?: string) {
+  public thenTransposedEquals<T, K extends keyof T>(transposed: Transposed<T, K>, type?: string) {
     expect(this._oatyArray!.transposed).to.deep.equal(transposed)
     if (type === 'Dummy') {
-      expect(this._oatyArray!.transposed!.data!.hello![0]).to.be.an.instanceOf(Dummy)
+      expect((this._oatyArray!.transposed! as unknown as any).data!.hello![0]).to.be.an.instanceOf(Dummy)
     }
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -36,8 +36,17 @@ describe('OatyArray', () => {
         fixture.givenOatyArray(initial)
         fixture.thenOatyArrayExists()
         fixture.thenOriginalsEquals(initial)
+        fixture.thenKeysEquals(["a", "b", "fruit"])
       })
     })
+
+    context('([], {keys})', () => {	
+      it('initialises', () => {	
+        fixture.givenOatyArray([], {keys: ['a', 'b', 'fruit']})	
+        fixture.thenOatyArrayExists()	
+        fixture.thenKeysEquals(['a', 'b', 'fruit'])	
+      })	
+    });
 
     context('([...], {keys})', () => {
       it('initialises', () => {
@@ -51,6 +60,15 @@ describe('OatyArray', () => {
         fixture.thenKeysEquals(['a'])
       })
     })
+  })
+
+  describe('.keys', () => {	
+    context('with initialised data', () => {	
+      it('returns initialised data', () => {	
+        fixture.givenOatyArray([], {keys: ['a']})	
+        fixture.thenKeysEquals(['a'])	
+      })	
+    })	
   })
 
   describe('.length', () => {
@@ -120,6 +138,31 @@ describe('OatyArray', () => {
       fixture.whenDataIsPushed(push)
       fixture.thenCountIs(6)
     })
+
+    it('transposes only .keys', () => {	
+      const keys = ['fruit']	
+      const push = [	
+       { a: 5, b: 5, fruit: 'potato' },	
+       { a: 6, b: 6, fruit: 'courgette' }]	
+      fixture.givenOatyArray([], {keys})	
+      fixture.whenDataIsPushed(push)	
+      fixture.thenTransposedEquals({	
+        fruit: {	
+          courgette: [{ a: 6, b: 6, fruit: 'courgette' }],	
+          potato: [{ a: 5, b: 5, fruit: 'potato' }],	
+        },	
+      })	
+    })	
+
+    it('does not tranpose objects with missing .keys', () => {	
+      const keys = ['fruit']	
+      const push = [	
+       { a: 5, b: 5 },	
+       { a: 6, b: 6 }]	
+      fixture.givenOatyArray([], {keys})	
+      fixture.whenDataIsPushed(push)	
+      fixture.thenTransposedEquals({})	
+    })
   })
 
   describe('.get', () => {
@@ -177,6 +220,16 @@ describe('OatyArray', () => {
             potato: [{ a: 5, b: 5, fruit: 'potato' }]})
         })
       })
+
+      context('querying for non-existent key', () => {	
+        it('throws a ReferenceError', () => {	
+          const testArray = [{ a: 1, b: 1}]	
+          fixture.givenOatyArray(testArray)	
+          expect(() => {	
+            fixture.whenGetIsCalled('fruit')	
+          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)	
+        })	
+      })
     })
     describe('(key, value)', () => {
       context('initialised data', () => {
@@ -214,6 +267,16 @@ describe('OatyArray', () => {
         })
       })
 
+      context('querying for non-existent key', () => {	
+        it('throws a ReferenceError', () => {	
+          const testArray = [{ a: 1, b: 1}]	
+          fixture.givenOatyArray(testArray)	
+          expect(() => {	
+            fixture.whenGetIsCalled('fruit', 'carrot')	
+          }).to.throw(ReferenceError, `The key 'fruit' has not been transposed`)	
+        })	
+      })
+
       context('querying for non-existent value', () => {
         it('returns undefined', () => {
           const testArray = [{ a: 1, b: 1, fruit: 'apple' }]
@@ -238,9 +301,9 @@ describe('OatyArray', () => {
     describe('.get', () => {
       describe('initialised data', () => {
         it('returns data of type T[]', () => {
-          fixture.givenOatyArray<Dummy>([new Dummy()])
+          fixture.givenOatyArray([new Dummy()])
           fixture.whenGetIsCalled('data', 'hello')
-          fixture.thenMatchesEquals<Dummy[]>([new Dummy()], 'Dummy')
+          fixture.thenMatchesEquals([new Dummy()], 'Dummy')
         })
       })
     })
@@ -248,7 +311,7 @@ describe('OatyArray', () => {
     describe('.transposed', () => {
       describe('initialised data', () => {
         it('returns data of type [T]', () => {
-          fixture.givenOatyArray<Dummy>([new Dummy()])
+          fixture.givenOatyArray([new Dummy()])
           fixture.thenTransposedEquals({
             data: {
               hello: [
@@ -269,7 +332,7 @@ class Fixture {
   private _count: number | undefined
   private _matches: { [key: string]: [any] } | any[] | undefined
 
-  public givenOatyArray<T>(data?: T[], options?: Options<keyof T>) {
+  public givenOatyArray(data?: any[], options?: Options<any>) {
     this._oatyArray = new OatyArray(data, options)
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -32,11 +32,13 @@ describe('OatyArray', () => {
       it('initialises', () => {
         const initial = [
          { a: 1, b: 1, fruit: 'apple' },
-         { a: 1, b: 3, fruit: 'banana' }]
+         { a: 1, b: 3, fruit: 'banana' }, 
+         { a: 2, b: 4, food: 'yum' }
+        ]
         fixture.givenOatyArray(initial)
         fixture.thenOatyArrayExists()
         fixture.thenOriginalsEquals(initial)
-        fixture.thenKeysEquals(["a", "b", "fruit"])
+        fixture.thenKeysEquals(["a", "b", "fruit", "food"])
       })
     })
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -38,3 +38,6 @@ expectType<{
 
 // Keys must be a subset of the available keys
 expectError(new OatyArray([{"a": 1, "b": 2}], {keys: ["f"]}))
+
+const myArray5 = new OatyArray([{ key1: "something", key3: "hello"}], { keys: ["key1"]})
+expectType<"key1"[]>(myArray5.keys)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,39 @@
+import { OatyArray } from "..";
+import { expectType, expectError } from "tsd";
+
+const myArray = new OatyArray([{test: 1, test1: 2 }], {keys: ["test", "test1"] });
+
+expectType<("test" | "test1")[]>(myArray.keys);
+expectType<{test: number, test1: number}[] | undefined>(myArray.get("test", 1));
+expectType<{test: number, test1: number}[] | undefined>(myArray.get("test")[1])
+
+// "test" can never be a string, so throw an error
+expectError(myArray.get("test", "something not a number"));
+// this key is not transposed, so a compile time error should be thrown
+expectError(myArray.get("somethingNotTransposed", "a"));
+expectError(myArray.push({test1: 1, test: "a"}));
+myArray.push({test1: 1, test: 1});
+
+const myArray2 = new OatyArray(undefined, { keys: ["1", "2", "3"]})
+expectType<("1" | "2" | "3")[]>(myArray2.keys);
+
+// 3 is a required key
+expectError(myArray2.push({1: "a", 2: "a"}))
+myArray2.push({1: "a", 2: "a", 3: 1, test1: 1, any: "something"})
+
+const myArray3 = new OatyArray();
+myArray3.push({ "a": 1, "b": 1, "c": 1, anything: "hello" });
+expectType<undefined>(myArray3.keys)
+
+const myArray4 = new OatyArray([{key1: 1, key2: 2 }, {key1: 2, key2: 3 }] as const, {keys: ["key1", "key2"] });
+
+// `key1` is never 5, so throw a compile time error
+expectError(myArray4.get("key1", 5));
+expectType<({readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined>(myArray4.get("key1", 1))
+expectType<{
+    1: ({readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined, 
+    2: ({ readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined
+}>(myArray4.get("key1"))
+
+// Keys must be a subset of the available keys
+expectError(new OatyArray([{"a": 1, "b": 2}], {keys: ["f"]}))

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -15,7 +15,7 @@ expectError(myArray.push({test1: 1, test: "a"}));
 myArray.push({test1: 1, test: 1});
 
 const myArray2 = new OatyArray(undefined, { keys: ["1", "2", "3"]})
-expectType<("1" | "2" | "3")[]>(myArray2.keys);
+expectType<("1" | "2" | "3")[] | undefined>(myArray2.keys);
 
 // 3 is a required key
 expectError(myArray2.push({1: "a", 2: "a"}))
@@ -23,7 +23,8 @@ myArray2.push({1: "a", 2: "a", 3: 1, test1: 1, any: "something"})
 
 const myArray3 = new OatyArray();
 myArray3.push({ "a": 1, "b": 1, "c": 1, anything: "hello" });
-expectType<undefined>(myArray3.keys)
+expectType<({ [x: string]: any; [x: number]: any; } & { [x: string]: any; [x: number]: any; })[] | undefined>(myArray3.get("a", 1))
+expectType<(string | number | symbol)[] | undefined>(myArray3.keys)
 
 const myArray4 = new OatyArray([{key1: 1, key2: 2 }, {key1: 2, key2: 3 }] as const, {keys: ["key1", "key2"] });
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -15,7 +15,7 @@ expectError(myArray.push({ test1: 1, test: "a" }));
 myArray.push({ test1: 1, test: 1 });
 
 const myArray2 = new OatyArray(undefined, { keys: ["1", "2", "3"] })
-expectType<("1" | "2" | "3")[] | undefined>(myArray2.keys);
+expectType<("1" | "2" | "3")[]>(myArray2.keys);
 
 // 3 is a required key
 expectError(myArray2.push({ 1: "a", 2: "a" }))
@@ -24,7 +24,7 @@ myArray2.push({ 1: "a", 2: "a", 3: 1, test1: 1, any: "something" })
 const myArray3 = new OatyArray();
 myArray3.push({ "a": 1, "b": 1, "c": 1, anything: "hello" });
 expectType<({ [x: string]: any;[x: number]: any; } & { [x: string]: any;[x: number]: any; })[] | undefined>(myArray3.get("a", 1))
-expectType<(string | number | symbol)[] | undefined>(myArray3.keys)
+expectType<(string | number | symbol)[]>(myArray3.keys)
 
 const myArray4 = new OatyArray([{ key1: 1, key2: 2 }, { key1: 2, key2: 3 }] as const, { keys: ["key1", "key2"] });
 
@@ -41,3 +41,6 @@ expectError(new OatyArray([{ "a": 1, "b": 2 }], { keys: ["f"] }))
 
 const myArray5 = new OatyArray([{ key1: "something", key3: "hello" }], { keys: ["key1"] })
 expectType<"key1"[]>(myArray5.keys)
+
+const myArray6 = new OatyArray([{ a: 1}, {b: 2}])
+expectType<("a" | "b")[]>(myArray6.keys);

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,43 +1,43 @@
 import { OatyArray } from "..";
 import { expectType, expectError } from "tsd";
 
-const myArray = new OatyArray([{test: 1, test1: 2 }], {keys: ["test", "test1"] });
+const myArray = new OatyArray([{ test: 1, test1: 2 }], { keys: ["test", "test1"] });
 
 expectType<("test" | "test1")[]>(myArray.keys);
-expectType<{test: number, test1: number}[] | undefined>(myArray.get("test", 1));
-expectType<{test: number, test1: number}[] | undefined>(myArray.get("test")[1])
+expectType<{ test: number, test1: number }[] | undefined>(myArray.get("test", 1));
+expectType<{ test: number, test1: number }[] | undefined>(myArray.get("test")[1])
 
 // "test" can never be a string, so throw an error
 expectError(myArray.get("test", "something not a number"));
 // this key is not transposed, so a compile time error should be thrown
 expectError(myArray.get("somethingNotTransposed", "a"));
-expectError(myArray.push({test1: 1, test: "a"}));
-myArray.push({test1: 1, test: 1});
+expectError(myArray.push({ test1: 1, test: "a" }));
+myArray.push({ test1: 1, test: 1 });
 
-const myArray2 = new OatyArray(undefined, { keys: ["1", "2", "3"]})
+const myArray2 = new OatyArray(undefined, { keys: ["1", "2", "3"] })
 expectType<("1" | "2" | "3")[] | undefined>(myArray2.keys);
 
 // 3 is a required key
-expectError(myArray2.push({1: "a", 2: "a"}))
-myArray2.push({1: "a", 2: "a", 3: 1, test1: 1, any: "something"})
+expectError(myArray2.push({ 1: "a", 2: "a" }))
+myArray2.push({ 1: "a", 2: "a", 3: 1, test1: 1, any: "something" })
 
 const myArray3 = new OatyArray();
 myArray3.push({ "a": 1, "b": 1, "c": 1, anything: "hello" });
-expectType<({ [x: string]: any; [x: number]: any; } & { [x: string]: any; [x: number]: any; })[] | undefined>(myArray3.get("a", 1))
+expectType<({ [x: string]: any;[x: number]: any; } & { [x: string]: any;[x: number]: any; })[] | undefined>(myArray3.get("a", 1))
 expectType<(string | number | symbol)[] | undefined>(myArray3.keys)
 
-const myArray4 = new OatyArray([{key1: 1, key2: 2 }, {key1: 2, key2: 3 }] as const, {keys: ["key1", "key2"] });
+const myArray4 = new OatyArray([{ key1: 1, key2: 2 }, { key1: 2, key2: 3 }] as const, { keys: ["key1", "key2"] });
 
 // `key1` is never 5, so throw a compile time error
 expectError(myArray4.get("key1", 5));
-expectType<({readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined>(myArray4.get("key1", 1))
+expectType<({ readonly key1: 1, readonly key2: 2 } | { readonly key1: 2, readonly key2: 3 })[] | undefined>(myArray4.get("key1", 1))
 expectType<{
-    1: ({readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined, 
-    2: ({ readonly key1: 1, readonly key2: 2 } | {readonly key1: 2, readonly key2: 3 })[] | undefined
+    1: ({ readonly key1: 1, readonly key2: 2 } | { readonly key1: 2, readonly key2: 3 })[] | undefined,
+    2: ({ readonly key1: 1, readonly key2: 2 } | { readonly key1: 2, readonly key2: 3 })[] | undefined
 }>(myArray4.get("key1"))
 
 // Keys must be a subset of the available keys
-expectError(new OatyArray([{"a": 1, "b": 2}], {keys: ["f"]}))
+expectError(new OatyArray([{ "a": 1, "b": 2 }], { keys: ["f"] }))
 
-const myArray5 = new OatyArray([{ key1: "something", key3: "hello"}], { keys: ["key1"]})
+const myArray5 = new OatyArray([{ key1: "something", key3: "hello" }], { keys: ["key1"] })
 expectType<"key1"[]>(myArray5.keys)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "./dist",
     "strict": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
     "lib": ["es2015", "es2017", "dom"]
   },
   "exclude": [


### PR DESCRIPTION
This PR makes `OatyArray` fully generic. It does this by ensuring that key definitions have to exist on the objects in the input array, and by ensuring that the `get` method will only accept queries for key and value types which do exist.

This meant removing some of the tests around checking errors when trying to access non existent keys, as they would be thrown at compile time. If you think these should be put back, that's fine. 

This addition also means that autocompletion is greatly improved when interacting `oaty`.

Here is an example of what these definitions give you:

### Typechecked access
```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}])
myArray.get("d") // ERROR: Argument of type '"d"' is not assignable to parameter of type '"a" | "b" | "c"'
```

```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}])
myArray.get("a", 10) // ERROR: Argument of type '10' is not assignable to parameter of type 'string'
```

```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}], { keys: ["c"]});
const values = myArray.get("b", 1); // Argument of type '"b"' is not assignable to parameter of type '"c"'.
```

### Correct return types
```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}])

const values = myArray.get("b");
values["a"] // ERROR: Element implicitly has an 'any' type because index expression is not of type 'number'
```
```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}])

const values = myArray.get("b");
values[1][0].d // ERROR: Property 'd' does not exist on type '{ a: string; b: number; c: number; }'
```

### Enforced `keys` input
```typescript
const myArray = new OatyArray([{ a: "a", b: 1, c: 50}], { keys: ["B"]}) // ERROR: Argument of type '{ keys: "B"[]; }' is not assignable to parameter of type 'Options<"a" | "b" | "c">'. Types of property 'keys' are incompatible.
```


